### PR TITLE
add support for raspberrypi

### DIFF
--- a/ARCHS
+++ b/ARCHS
@@ -1,3 +1,4 @@
 x86_64
 arm64
 armhf
+aarch64_cortex-a72


### PR DESCRIPTION
As mentioned in #4, I added `aarch64_cortex-a72` to support Raspberry Pi 4